### PR TITLE
#1: Improving Playbooks vastly with default(omit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple role for managing users and groups with Ansible.
 
+## Version
+
+1.0.1
+
 ## Role Variables
 
 We have a variable for defining groups:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple role for managing users and groups with Ansible.
 
 ## Version
 
-1.0.1
+1.0.2
 
 ## Role Variables
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -6,28 +6,10 @@
     state: "{{item.value.state|default('present')}}"
     system: "{{item.value.system|default(false)}}"
     comment: "{{item.key}}"
+    uid: "{{item.value.uid|default(omit)}}"
+    home: "{{item.value.home|default(omit)}}"
+    groups: "{{item.value.groups|default(omit)|join(',')}}"
   with_dict: autologic_users
-
-- name: Configure user UIDs
-  user:
-    name: "{{item.value.username}}"
-    uid: "{{item.value.uid}}"
-  with_dict: autologic_users
-  when: item.value.uid is defined
-
-- name: Configure user home directory
-  user:
-    name: "{{item.value.username}}"
-    home: "{{item.value.home}}"
-  with_dict: autologic_users
-  when: item.value.home is defined
-
-- name: Configure user groups
-  user:
-    name: "{{item.value.username}}"
-    groups: "{{item.value.groups|join(',')}}"
-  with_dict: autologic_users
-  when: item.value.groups is defined
 
 - name: Add user SSH (public) keys
   authorized_key:

--- a/tasks/users_department_pattern.yml
+++ b/tasks/users_department_pattern.yml
@@ -6,29 +6,11 @@
     state: "{{item.value.state|default('present')}}"
     system: "{{item.value.system|default(false)}}"
     comment: "{{item.key}}"
+    uid: "{{item.value.uid|default(omit)}}"
+    home: "{{item.value.home|default(omit)}}"
+    groups: "{{item.value.groups|default(omit)|join(',')}}"
   with_dict: autologic_users
   when: item.value.department in autologic_departments
-
-- name: Configure user UIDs (department pattern)
-  user:
-    name: "{{item.value.username}}"
-    uid: "{{item.value.uid}}"
-  with_dict: autologic_users
-  when: item.value.uid is defined and item.value.department in autologic_departments
-
-- name: Configure user home directory (department pattern)
-  user:
-    name: "{{item.value.username}}"
-    home: "{{item.value.home}}"
-  with_dict: autologic_users
-  when: item.value.home is defined and item.value.department in autologic_departments
-
-- name: Configure user groups (department pattern)
-  user:
-    name: "{{item.value.username}}"
-    groups: "{{item.value.groups|join(',')}}"
-  with_dict: autologic_users
-  when: item.value.groups is defined and item.value.department in autologic_departments
 
 - name: Add user SSH (public) keys (department pattern)
   authorized_key:


### PR DESCRIPTION
Implementing default(omit) has vastly improved the Playbook readability, lowered the complexity, and resulted in a faster run.

This is also the chance to get version control in here and proper issue management.
