### PR TITLE
BUG: Groups using omit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Manage system groups and users using nothing but easy to read dictionaries. Usin
 
 ## Version
 
-2.0.0
+2.0.1
 
 ## Role Variables
 

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,7 +8,7 @@
     comment:  "{{item.key}}"
     uid:      "{{item.value.uid|default(omit)}}"
     home:     "{{item.value.home|default(omit)}}"
-    groups:   "{{item.value.groups|default(omit)|join(',')}}"
+    groups:   "{{item.value.groups|default([])|join(',')}}"
     remove:   "{{item.value.remove|default(false)}}"
     force:    "{{item.value.force|default(false)}}"
   with_dict:  autologic_system_users


### PR DESCRIPTION
Can't use omit and then try to join. Must use an empty list.
